### PR TITLE
Make sure that we don't trample over other options 

### DIFF
--- a/Source/NSJSONSerialization+RemovingNulls.m
+++ b/Source/NSJSONSerialization+RemovingNulls.m
@@ -11,13 +11,18 @@
     if (removingNulls)
     {
         // Force add NSJSONReadingMutableContainers since the null removal depends on it.
-        opt = opt || NSJSONReadingMutableContainers;
+        opt = opt | NSJSONReadingMutableContainers;
     }
     
     id JSONObject = [self JSONObjectWithData:data options:opt error:error];
     
     if ((error && *error) || !removingNulls)
     {
+        return JSONObject;
+    }
+    
+    if (![JSONObject isKindOfClass:[NSArray class]] && ![JSONObject isKindOfClass:[NSDictionary class]]) {
+        
         return JSONObject;
     }
     

--- a/Tests/JRTNullStrippingTest.m
+++ b/Tests/JRTNullStrippingTest.m
@@ -10,18 +10,6 @@
 
 @implementation JRTNullStrippingTest
 
-- (void)setUp
-{
-    [super setUp];
-    // Put setup code here; it will be run once, before the first test case.
-}
-
-- (void)tearDown
-{
-    // Put teardown code here; it will be run once, after the last test case.
-    [super tearDown];
-}
-
 -(void)testRemoveNullsAtTopLevelFromDictionary
 {
     NSMutableDictionary *dictionaryWithNulls = [self dictionaryWithNulls];
@@ -175,6 +163,19 @@
     NSArray *array = [NSJSONSerialization JSONObjectWithData:arrayData options:NSJSONReadingMutableContainers error:&category removingNulls:YES ignoreArrays:NO];
     XCTAssertNil(standard);
     XCTAssertFalse([array containsObject:[NSNull null]]);
+}
+
+-(void)testForceMutableContainersPreservesFragmentParsing {
+    
+    NSData *fragmentData = [@"32" dataUsingEncoding:NSUTF8StringEncoding];
+    
+    NSError *standard = nil;
+    NSError *category = nil;
+    [NSJSONSerialization JSONObjectWithData:fragmentData options:NSJSONReadingAllowFragments error:&standard];
+    NSNumber *number = [NSJSONSerialization JSONObjectWithData:fragmentData options:NSJSONReadingAllowFragments error:&category removingNulls:YES ignoreArrays:NO];
+    
+    XCTAssertNil(standard);
+    XCTAssertNotNil(number);
 }
 
 @end


### PR DESCRIPTION
If you use the fragments option or any bit mask value it will be set to NSJSONReadingMutableContainers only.

The force setting is using the logical operator instead of the bitwise operator.
